### PR TITLE
1.15 branch pack_format from 4 to 5

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 4,
+    "pack_format": 5,
     "description": "Faithful for §fJava Edition§r\n§6Authors:§r §cxMrVizzy & Vattic"
   }
 }


### PR DESCRIPTION
Since the valid pack_format for Minecraft 1.15 is **5** and not **4**, the resource pack shows up as incompatible after fixing the file structure.